### PR TITLE
Fixed Lighting and movement graphic glitch

### DIFF
--- a/client/src/@core/Graphic.tsx
+++ b/client/src/@core/Graphic.tsx
@@ -43,7 +43,7 @@ export default memo(
             frameTime = 200,
             scale = 1,
             flipX = 1,
-            color = '#fff',
+            color = '#999',
             opacity = 1,
             offset = { x: 0, y: 0 },
             basic,
@@ -63,7 +63,7 @@ export default memo(
 
         const image = useAsset(src) as HTMLImageElement;
         const textureRef = useRef<THREE.Texture>()
-        
+
         useLayoutEffect(() => {
             textureRef.current.needsUpdate = true;
         }, []);
@@ -141,25 +141,21 @@ export default memo(
                 repeat: new THREE.Vector2(1 / size.x, 1 / size.y),
                 magFilter,
                 minFilter: THREE.LinearMipMapLinearFilter,
+                color: "#999"
             };
         }, [frameHeight, frameWidth, image, magFilter]);
 
         return (
             <mesh
-                // ref={ref}
+                //@ts-ignore
+                ref={ref}
                 position={[offset.x, offset.y, -offset.y / 100]}
                 scale={[flipX * scale, scale, 1]}
                 geometry={geometry}
             >
-                {basic ? (
-                    <meshBasicMaterial attach="material" {...materialProps}>
-                        <texture ref={textureRef} attach="map" {...textureProps} />
-                    </meshBasicMaterial>
-                ) : (
-                    <meshLambertMaterial attach="material" {...materialProps}>
-                        <texture ref={textureRef} attach="map" {...textureProps} />
-                    </meshLambertMaterial>
-                )}
+                <meshBasicMaterial attach="material" {...materialProps}>
+                    <texture ref={textureRef} attach="map" {...textureProps} />
+                </meshBasicMaterial>
             </mesh>
         );
     })

--- a/client/src/@core/Moveable.tsx
+++ b/client/src/@core/Moveable.tsx
@@ -98,7 +98,6 @@ export default function Moveable({ isStatic = false }: Props) {
             const toY = targetPosition.y;
 
             anime.remove(nodeRef.current.position);
-
             await anime({
                 targets: nodeRef.current.position,
                 x: [fromX, toX],
@@ -106,8 +105,14 @@ export default function Moveable({ isStatic = false }: Props) {
                 duration: movementDuration,
                 easing: 'linear',
                 begin() {
-                    if (dirX) transform.setX(targetPosition.x);
-                    if (dirY) transform.setY(targetPosition.y);
+                    if (dirX) {
+                        setTimeout(() => { transform.setX(targetPosition.x); }, 200);
+                        ;
+                    }
+                    if (dirY) {
+                        setTimeout(() => {  transform.setY(targetPosition.y); }, 200);
+                        
+                    }
                 },
                 update() {
                     !isForced &&
@@ -119,7 +124,6 @@ export default function Moveable({ isStatic = false }: Props) {
                         });
                 },
             }).finished;
-
             canMove.current = true;
 
             publish<DidChangePositionEvent>('did-change-position', targetPosition);


### PR DESCRIPTION
- Fixed lighting by adjusting the initial lighting to a darker grey
- A hook was called multiple times when updating the player movement position and animation sequentially. Changed the animation to have a delay in order to not re-render character multiple times in a single key press.